### PR TITLE
Corrections to volume mounting and the compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,13 @@ services:
   dumpster-api:
     build: dumpster-api
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 4001 -b '0.0.0.0'"
+    # This will connect our local directory /dumpster-api with the docker file system
+    volumes:
+      - .dumpster-api:/dumpster-api-vol
     ports:
       - "4001:4001"
   rails-client:
-    build: rails-rails
+    build: rails-client
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3001 -b '0.0.0.0'"
     ports:
       - "3001:3001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
   rails-client:
     build: rails-client
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3001 -b '0.0.0.0'"
+    # This will connect our local directory /dumpster-api with the docker file system
+    volumes:
+      - .rails-client:/rails-client-vol
     ports:
       - "3001:3001"
     depends_on:

--- a/dumpster-api/Dockerfile
+++ b/dumpster-api/Dockerfile
@@ -5,22 +5,9 @@ RUN apt-get update -qq && apt-get install -y nodejs
 
 # Note that myapp is not related to our current working dir
 # I'll try to see if I can omit all this later...?
-RUN mkdir /myapp
-WORKDIR /myapp
-COPY Gemfile /myapp/Gemfile
-COPY Gemfile.lock /myapp/Gemfile.lock
+#RUN mkdir /myapp
+WORKDIR /dumpster-api-vol
+COPY Gemfile /dumpster-api-vol/Gemfile
+COPY Gemfile.lock /dumpster-api-vol/Gemfile.lock
 RUN bundle install
-COPY . /myapp
-
-
-#
-# Killing this portion since I think the compose will take care of it...
-#
-# Weird necessary hack according to docs
-#COPY entrypoint.sh /usr/bin/
-#RUN chmod +x /usr/bin/entrypoint.sh
-#ENTRYPOINT ["entrypoint.sh"]
-#EXPOSE 4001
-
-# Normal rails s
-#CMD ["rails", "server", "-b", "0.0.0.0"]
+COPY . /dumpster-api-vol

--- a/dumpster-api/entrypoint.sh
+++ b/dumpster-api/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-# Remove a potentially pre-existing server.pid for Rails.
-rm -f /myapp/tmp/pids/server.pid
-
-# Then exec the container's main process (what's set as CMD in the Dockerfile).
-exec "$@"

--- a/rails-client/Dockerfile
+++ b/rails-client/Dockerfile
@@ -5,9 +5,9 @@ RUN apt-get update -qq && apt-get install -y nodejs
 
 # Note that myapp is not related to our current working dir
 # I'll try to see if I can omit all this later...?
-RUN mkdir /myapp
-WORKDIR /myapp
-COPY Gemfile /myapp/Gemfile
-COPY Gemfile.lock /myapp/Gemfile.lock
+RUN mkdir /rails-client-vol
+WORKDIR /rails-client-vol
+COPY Gemfile /rails-client-vol/Gemfile
+COPY Gemfile.lock /rails-client-vol/Gemfile.lock
 RUN bundle install
-COPY . /myapp
+COPY . /rails-client-vol

--- a/rails-client/Dockerfile
+++ b/rails-client/Dockerfile
@@ -11,15 +11,3 @@ COPY Gemfile /myapp/Gemfile
 COPY Gemfile.lock /myapp/Gemfile.lock
 RUN bundle install
 COPY . /myapp
-
-#
-# Killing this portion since I think the compose will take care of it...
-#
-# Weird necessary hack according to docs
-#COPY entrypoint.sh /usr/bin/
-#RUN chmod +x /usr/bin/entrypoint.sh
-#ENTRYPOINT ["entrypoint.sh"]
-#EXPOSE 4001
-
-# Normal rails s
-#CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/rails-client/entrypoint.sh
+++ b/rails-client/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-# Remove a potentially pre-existing server.pid for Rails.
-rm -f /myapp/tmp/pids/server.pid
-
-# Then exec the container's main process (what's set as CMD in the Dockerfile).
-exec "$@"


### PR DESCRIPTION
- Volume mounting wasn't there, so when I did `rails new` and stuff in the scope of the container, it never propagated back into my local file system. That's now fixed.
- Corrected the `Dockerfile` setup so that they create volumes with names that are obvious
- Killed entrypoint shell script since I don't think it will matter if I'm using a compose. I can always revive it later.